### PR TITLE
[Sentinel] fix(issues/retry-1-3ebd8a-8332fe.txt): Nordic/European characters (ä, ö, ü, Ö, etc.) are rejected b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+
+## [23a107a4] Sentinel auto-fix
+- Source: issues/retry-1-3ebd8a-8332fe.txt
+- Error: Nordic/European characters (ä, ö, ü, Ö, etc.) are rejected by the input validation in Whydah-TypeLib, causing 500 errors
+- Fingerprint: `a15857d5bb6c26cc`

--- a/src/main/java/net/whydah/sso/basehelpers/Validator.java
+++ b/src/main/java/net/whydah/sso/basehelpers/Validator.java
@@ -152,7 +152,7 @@ public class Validator {
 
 	public static final String DEFAULT_TEXT_WITH_ONLY_LETTERS = "^[a-zA-Z\\p{L}]+$";
 	public static final String DEFAULT_SENSIBLE_PERSON_NAME = "^[a-zæøåéćíúáäýóööôðüñA-ZÆØÅÑ]+(([',. -][a-zæøöåéćíúöáäýóôðüñA-ZÆØÅÑ ])?[a-zæøöåäéćíáýóúôðüñA-ZÆØÅÑ0-9.]*)*$";
-	public static final String DEFAULT_SENSIBLE_ESCAPED_JSON = "^[a-zæøåéáíóúôöüñA-ZÆØÅÑ0-9-#?_.,'/+:@{}\\\\ \\\"=\\[\\]]+$";
+	public static final String DEFAULT_SENSIBLE_ESCAPED_JSON = "^[\\p{L}a-zæøåéáíóúôöüñA-ZÆØÅÑ0-9-#?_.,'/+:@{}\\\\ \\\"=\\[\\]]+$";
 
 	public static final boolean DEFAULT_CHECK_INVALID_HTML_USE = false;
 

--- a/src/main/java/net/whydah/sso/ddd/model/base/AssertionConcern.java
+++ b/src/main/java/net/whydah/sso/ddd/model/base/AssertionConcern.java
@@ -43,6 +43,7 @@ public class AssertionConcern {
     }
 
     protected void assertArgumentWithSafeJsonInput(String aString, int aMinimum, int aMaximum, String aMessage) {
+        log.info("sentinel-a15857d5 sentinel-auto-fix [safe to remove after verification]");
         boolean isValid = Validator.isValidJsonInput(aString, aMinimum, aMaximum);
         if (!isValid) {
             throwException(aMessage);


### PR DESCRIPTION
## Auto-generated fix by Sentinel

**Error fingerprint**: `a15857d5bb6c26cc`  
**Source**: `issues/retry-1-3ebd8a-8332fe.txt` / ``  
**First seen**: 2026-03-25T16:13:36.433750+00:00

### Error
```
Nordic/European characters (ä, ö, ü, Ö, etc.) are rejected by the input validation in Whydah-TypeLib, causing 500 errors in production.
Nordic/European characters (ä, ö, ü, Ö, etc.) are rejected by the input validation in Whydah-TypeLib, causing 500 errors in production.

**Customer feedback (Norwegian):** "Hei, kan dere legge til Ö som godkjent character? Fikk tilbakemelding fra kundeservice om det" — requesting Ö be added as an accepted character.

**Production errors (SSOLWA, PROD):** 3 occurrences on 2026-03-23 between 10:18–10:19 UTC. A customer named "Emilie Clarice Schäffer" triggers IllegalArgumentException when loading /sso/profile because the ä in "Schäffer" fails validation.

**Stack trace:**
```
```

### Commits in this fix
| SHA (short) | Description |
|---|---|
| `23a107a4` | fix(sentinel): Nordic/European characters (ä, ö, ü, Ö, etc.) are rejected b |

---
_To apply: merge this PR. To reject: close it. Sentinel will not retry this fingerprint for 24 h._