### PR TITLE
fix(deps): bump Jackson to 2.21.5 (CVE-2026-54512, CVE-2026-54515)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.22.1</version>
+            <version>2.21.5</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.jsoup/jsoup -->
         <dependency>


### PR DESCRIPTION
## Jackson CVE patch

Bumps Jackson to **2.21.5** (LTS) to remediate:
- **CVE-2026-54512** — jackson-databind RCE via PolymorphicTypeValidator bypass
- **CVE-2026-54515** — case-insensitive deserialization re-opens `@JsonIgnore` fields

Fixes exist only on the 2.18.x / 2.21.x (LTS) / 3.1.4 lines — there is **no fixed 2.22.x**, and 2.22.0 is flagged vulnerable — so this moves onto the patched **2.21 LTS** line.

Part of the coordinated Whydah Jackson release train (TypeLib → Java-SDK → Admin-SDK → services); release cut via Jenkins after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)